### PR TITLE
Fix #198

### DIFF
--- a/searchf/app.py
+++ b/searchf/app.py
@@ -4,6 +4,7 @@ import copy
 import curses
 import curses.ascii
 import os
+import pathlib
 import sys
 
 from curses.textpad import Textbox
@@ -23,7 +24,7 @@ USE_DEBUG = False
 STATUS_UNCHANGED = 'unchanged'
 
 
-def load_lines(path: str) -> List[str]:
+def load_lines(path: pathlib.Path) -> List[str]:
     '''Load all the lines of the given file.'''
     with open(path, encoding='utf-8') as f:
         # splitlines() ensures that any newline char is removed
@@ -109,7 +110,7 @@ class App:
         self._scr: Any = None
         self._margins: types.Margins = types.Margins()
         self._show_events: bool = False
-        self._path: str = ''
+        self._path: pathlib.Path = pathlib.Path()
         self._views: List[views.TextView] = []
         self._help_view_index: int = -1
         self._current: int = -1
@@ -193,7 +194,7 @@ class App:
             scr,
             margins: types.Margins,
             show_events: bool,
-            path: str,
+            path: pathlib.Path,
     ) -> None:
         '''Creates all views in the given screen, and loads the content from
         the given file.'''
@@ -205,7 +206,7 @@ class App:
         self._views.append(views.TextView(store, scr, 'View 1', path))
         self._views.append(views.TextView(store, scr, 'View 2', path))
         self._views.append(views.TextView(store, scr, 'View 3', path))
-        self._views.append(views.TextView(store, scr, 'Help', 'Help'))
+        self._views.append(views.TextView(store, scr, 'Help', pathlib.Path()))
         self._help_view_index = len(self._views) - 1
         self._views[self._help_view_index].get_config().line_numbers = False
         if USE_DEBUG:

--- a/searchf/main.py
+++ b/searchf/main.py
@@ -3,6 +3,7 @@
 import os
 import argparse
 import curses
+import pathlib
 
 from . import __version__
 from . import __url__
@@ -25,6 +26,14 @@ def _load_help_lines():
     lines += [f'  {__url__}']
     lines += [f'  {__url__}/releases/tag/{__version__}']
     return lines
+
+
+def _valid_path(path_str: str) -> pathlib.Path:
+    path = pathlib.Path(path_str)
+    if not path.exists():
+        raise argparse.ArgumentTypeError(
+            f"The file '{path_str}' does not exist.")
+    return path
 
 
 HELP_LINES = _load_help_lines()
@@ -59,7 +68,7 @@ class StatusView:
 
 
 def main_loop(scr,
-              path: str,
+              path: pathlib.Path,
               use_debug: bool,
               show_events: bool,
               keys_processor: keys.Processor
@@ -100,7 +109,7 @@ def main_loop(scr,
 def main_curses(scr, args) -> None:
     '''Main entry point requiring curse environment.'''
     main_loop(scr,
-              args.file,
+              args.FILE,
               args.debug,
               args.show_events,
               keys.Processor(scr, curses))
@@ -116,7 +125,9 @@ def init_env() -> argparse.ArgumentParser:
 highlight keywords.',
         epilog='Press ? in the application for more information, or go to \
 https://github.com/human3/searchf')
-    parser.add_argument('file')
+    parser.add_argument('FILE',
+                        type=_valid_path,
+                        help="Path to the file to interactively search into")
     parser.add_argument('--debug',
                         help='Use debug layout',
                         action='store_true')

--- a/searchf/models.py
+++ b/searchf/models.py
@@ -32,6 +32,7 @@ SIndex = NewType('SIndex', int)
 # DIndex type carries an index into an array of display lines
 DIndex = NewType('DIndex', int)
 
+
 class DisplayLine(NamedTuple):
     '''Holds data associated with a single displayable line on the screen. Each
     line in the original file might not entirely fit on screen, and can be
@@ -295,14 +296,16 @@ class SelectedContent:
             for i, mdata in enumerate(self._lines):
                 sel_line_idx = SIndex(i)
                 d_line_idx = DIndex(len(dlines))
-                assert len(firstdlines) == sel_line_idx, f'{len(firstdlines)} {sel_line_idx}'
+                assert len(firstdlines) == sel_line_idx, \
+                    f'{len(firstdlines)} {sel_line_idx}'
                 firstdlines.append(d_line_idx)
                 dlines.append(DisplayLine(sel_line_idx, 0))
         else:
             for i, mdata in enumerate(self._lines):
                 sel_line_idx = SIndex(i)
                 d_line_idx = DIndex(len(dlines))
-                assert len(firstdlines) == sel_line_idx, f'{len(firstdlines)} {sel_line_idx}'
+                assert len(firstdlines) == sel_line_idx, \
+                    f'{len(firstdlines)} {sel_line_idx}'
                 firstdlines.append(d_line_idx)
                 line_idx, _, text, _ = mdata
                 offset = 0

--- a/searchf/test/all.py
+++ b/searchf/test/all.py
@@ -4,6 +4,7 @@
 import argparse
 import curses
 import os
+import pathlib
 import time
 
 from typing import List
@@ -28,10 +29,8 @@ from . import test_segments
 from . import test_sgr
 from . import test_storage
 
-TEST_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         'sample.txt')
-TEST_FILE_C = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                           'sample_with_colors.txt')
+TEST_FILE = pathlib.Path(os.path.dirname(__file__), 'sample.txt')
+TEST_FILE_C = pathlib.Path(os.path.dirname(__file__), 'sample_with_colors.txt')
 
 
 class KeywordsInjector:
@@ -128,7 +127,7 @@ class AppTest(NamedTuple):
 HANDLE_EVENT_DELAY = 0.01
 
 
-def _run(stdscr, t: AppTest, f: str):
+def _run(stdscr, t: AppTest, f: pathlib.Path):
     '''Helper function to run the given AppTest'''
     print(t.description)
     stdscr.clear()
@@ -387,7 +386,7 @@ def _test_main_main():
 
     def _init_env():
         parser = argparse.ArgumentParser(description='Dummy parser')
-        parser.add_argument('-file', default=TEST_FILE)
+        parser.add_argument('-FILE', default=TEST_FILE)
         parser.add_argument('-debug', default=False)
         parser.add_argument('-show-events', default=False)
         print('test_env')

--- a/searchf/views.py
+++ b/searchf/views.py
@@ -2,7 +2,7 @@
 
 import curses
 import curses.ascii
-import os
+import pathlib
 import re
 import sys
 
@@ -58,7 +58,7 @@ class TextView:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, store, scr, name: str, path: str) -> None:
+    def __init__(self, store, scr, name: str, path: pathlib.Path) -> None:
         self._raw: models.RawContent = \
             models.RawContent()
         self._selected: models.SelectedContent = \
@@ -70,7 +70,7 @@ class TextView:
         self._store = store
         self._scr = scr
         self._name: str = name
-        self._basename: str = os.path.basename(path)
+        self._basename: str = path.name
         # self._win: Optional[curses._CursesWindow]
         self._win: Any = None
         self._size: types.Size = (0, 0)


### PR DESCRIPTION
- Show proper error message when file does not exist
- Using pathlib.Path instead of str